### PR TITLE
Generate Manhattan background map layout

### DIFF
--- a/Assets/Maps/DowntownManhattan/downtown_manhattan_fictional.svg
+++ b/Assets/Maps/DowntownManhattan/downtown_manhattan_fictional.svg
@@ -1,0 +1,141 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="4096" height="2304" viewBox="0 0 4096 2304" version="1.1">
+	<title>Fictional Downtown Manhattan - Background Map</title>
+	<desc>Stylized, game-ready background map for a fictional Downtown Manhattan layout. Organized in layers for Unity parallax and sorting.</desc>
+	<defs>
+		<style type="text/css"><![CDATA[
+			.water { fill: #0b3d59; }
+			.land { fill: #f3efe6; stroke: #c3bfb1; stroke-width: 3; }
+			.park { fill: #89b36a; stroke: #6c9251; stroke-width: 2; }
+			.road-arterial { fill: none; stroke: #e8e6df; stroke-width: 12; stroke-linecap: round; }
+			.road-secondary { fill: none; stroke: #d9d6cd; stroke-width: 6; stroke-linecap: round; }
+			.road-tertiary { fill: none; stroke: #c9c5bb; stroke-width: 4; stroke-linecap: round; }
+			.bridge { fill: none; stroke: #e6e2d4; stroke-width: 10; stroke-linecap: round; stroke-dasharray: 26 10; }
+			.pier { fill: #34495e; }
+			.building-back { fill: #d7d3c7; }
+			.building-front { fill: #bdb8aa; }
+			.shoreline { fill: none; stroke: rgba(0,0,0,0.06); stroke-width: 10; }
+			.overlay { fill: none; }
+		]]></style>
+	</defs>
+
+	<!-- Water background -->
+	<g id="layer-water" data-layer="water" data-parallax-x="0.2" data-parallax-y="0.2">
+		<rect class="water" x="0" y="0" width="4096" height="2304"/>
+	</g>
+
+	<!-- Landmass of fictional lower Manhattan island silhouette -->
+	<g id="layer-land" data-layer="land" data-parallax-x="0.4" data-parallax-y="0.4">
+		<path class="land" d="M 640 2100
+			C 780 2050, 980 2030, 1130 1980
+			S 1470 1860, 1590 1770
+			S 1780 1620, 1900 1540
+			S 2120 1410, 2260 1310
+			S 2450 1150, 2540 1030
+			S 2660 860, 2720 720
+			S 2790 560, 2820 420
+			S 2850 260, 2880 220
+			S 2950 190, 3040 260
+			S 3150 430, 3220 520
+			S 3380 730, 3500 860
+			S 3610 1000, 3720 1160
+			S 3800 1350, 3850 1520
+			S 3870 1680, 3830 1800
+			S 3720 1960, 3600 2040
+			S 3450 2120, 3240 2180
+			S 3000 2240, 2800 2260
+			S 2520 2270, 2280 2260
+			S 1900 2230, 1660 2200
+			S 1350 2160, 1150 2140
+			S 900 2120, 760 2110
+			Z"/>
+		<!-- Subtle shoreline accent -->
+		<path class="shoreline" d="M 700 2080
+			C 840 2040, 1040 2020, 1200 1980
+			S 1530 1880, 1650 1790
+			S 1840 1640, 1980 1560
+			S 2200 1430, 2340 1330
+			S 2520 1180, 2620 1050
+			S 2740 880, 2800 740
+			S 2870 580, 2900 440
+			S 2930 280, 2960 240
+			S 3030 210, 3120 280
+			S 3230 450, 3300 540
+			S 3460 750, 3580 880
+			S 3690 1020, 3800 1180"/>
+	</g>
+
+	<!-- Parks -->
+	<g id="layer-parks" data-layer="parks" data-parallax-x="0.45" data-parallax-y="0.45">
+		<path class="park" d="M 1280 1950 C 1340 1910, 1420 1890, 1500 1900 C 1560 1910, 1600 1930, 1640 1970 C 1600 2010, 1520 2040, 1440 2040 C 1360 2030, 1300 1990, 1280 1950 Z"/>
+		<path class="park" d="M 1980 1580 C 2050 1540, 2140 1530, 2200 1560 C 2260 1590, 2280 1640, 2240 1680 C 2180 1720, 2080 1730, 2020 1700 C 1980 1670, 1960 1620, 1980 1580 Z"/>
+		<path class="park" d="M 2600 1060 C 2660 1020, 2720 1000, 2780 1000 C 2820 1040, 2830 1100, 2800 1140 C 2740 1160, 2680 1160, 2620 1140 C 2600 1120, 2590 1090, 2600 1060 Z"/>
+	</g>
+
+	<!-- Piers on west side -->
+	<g id="layer-piers" data-layer="piers" data-parallax-x="0.35" data-parallax-y="0.35">
+		<rect class="pier" x="950" y="2000" width="40" height="160"/>
+		<rect class="pier" x="1005" y="1990" width="42" height="170"/>
+		<rect class="pier" x="1060" y="1980" width="40" height="180"/>
+		<rect class="pier" x="1115" y="1970" width="42" height="190"/>
+		<rect class="pier" x="1170" y="1960" width="40" height="200"/>
+	</g>
+
+	<!-- Roads: Arterials (fictional) -->
+	<g id="layer-roads-arterial" data-layer="roads-arterial" data-parallax-x="0.55" data-parallax-y="0.55">
+		<!-- West Side Highway analog -->
+		<path class="road-arterial" d="M 900 2090 L 1200 2050 L 1500 1990 L 1780 1880 L 1980 1760 L 2160 1620 L 2320 1460 L 2460 1280 L 2580 1100 L 2680 920 L 2740 760 L 2790 620 L 2820 480"/>
+		<!-- FDR Drive analog -->
+		<path class="road-arterial" d="M 2100 1860 L 2300 1720 L 2460 1560 L 2600 1380 L 2700 1200 L 2780 1020 L 2840 840 L 2880 700 L 2920 540"/>
+		<!-- Canal St analog -->
+		<path class="road-arterial" d="M 1200 1950 L 1520 1960 L 1800 1940 L 2080 1880 L 2340 1780 L 2560 1660 L 2740 1520 L 2880 1360"/>
+		<!-- Broadway diagonal analog -->
+		<path class="road-arterial" d="M 940 2100 L 1180 2010 L 1400 1900 L 1620 1760 L 1820 1600 L 2020 1420 L 2200 1240 L 2360 1060 L 2500 900 L 2620 760 L 2720 620 L 2800 520"/>
+		<!-- Brooklyn Bridge analog -->
+		<path class="bridge" d="M 2460 1520 C 2600 1460, 2760 1420, 2900 1380 C 3040 1340, 3220 1300, 3360 1260"/>
+	</g>
+
+	<!-- Roads: Secondary grid (fictionalized) -->
+	<g id="layer-roads-secondary" data-layer="roads-secondary" data-parallax-x="0.6" data-parallax-y="0.6">
+		<!-- Horizontal streets -->
+		<path class="road-secondary" d="M 1000 2020 L 1420 1980 L 1780 1900 L 2100 1800 L 2380 1660 L 2620 1500"/>
+		<path class="road-secondary" d="M 1040 2060 L 1460 2010 L 1820 1920 L 2140 1820 L 2420 1680 L 2660 1520"/>
+		<path class="road-secondary" d="M 1120 2090 L 1520 2030 L 1880 1940 L 2200 1840 L 2480 1700 L 2720 1540"/>
+		<!-- Vertical avenues -->
+		<path class="road-secondary" d="M 1340 2060 L 1400 1880 L 1540 1720 L 1680 1580 L 1820 1460 L 1960 1340"/>
+		<path class="road-secondary" d="M 1600 2010 L 1680 1840 L 1800 1700 L 1940 1560 L 2100 1440 L 2240 1320"/>
+		<path class="road-secondary" d="M 1840 1940 L 1940 1780 L 2060 1640 L 2200 1500 L 2360 1380 L 2500 1260"/>
+	</g>
+
+	<!-- Roads: Tertiary/local -->
+	<g id="layer-roads-tertiary" data-layer="roads-tertiary" data-parallax-x="0.62" data-parallax-y="0.62">
+		<path class="road-tertiary" d="M 1460 1950 L 1500 1880 L 1600 1800 L 1700 1720"/>
+		<path class="road-tertiary" d="M 1680 1880 L 1720 1800 L 1820 1720 L 1920 1640"/>
+		<path class="road-tertiary" d="M 1900 1800 L 1960 1720 L 2060 1640 L 2160 1560"/>
+		<path class="road-tertiary" d="M 1320 2000 L 1360 1920 L 1460 1840 L 1560 1760"/>
+	</g>
+
+	<!-- Buildings: back layer blocks -->
+	<g id="layer-buildings-back" data-layer="buildings-back" data-parallax-x="0.7" data-parallax-y="0.7">
+		<rect class="building-back" x="1380" y="1920" width="80" height="110" rx="8"/>
+		<rect class="building-back" x="1460" y="1860" width="90" height="140" rx="8"/>
+		<rect class="building-back" x="1580" y="1780" width="110" height="160" rx="8"/>
+		<rect class="building-back" x="1700" y="1680" width="120" height="170" rx="8"/>
+		<rect class="building-back" x="1840" y="1580" width="120" height="180" rx="8"/>
+		<rect class="building-back" x="1980" y="1460" width="130" height="190" rx="8"/>
+		<rect class="building-back" x="2120" y="1340" width="120" height="170" rx="8"/>
+	</g>
+
+	<!-- Buildings: front layer silhouettes -->
+	<g id="layer-buildings-front" data-layer="buildings-front" data-parallax-x="0.8" data-parallax-y="0.8">
+		<rect class="building-front" x="1200" y="2000" width="120" height="180" rx="8"/>
+		<rect class="building-front" x="1320" y="1980" width="140" height="220" rx="8"/>
+		<rect class="building-front" x="1500" y="1920" width="150" height="260" rx="8"/>
+		<rect class="building-front" x="1680" y="1860" width="160" height="280" rx="8"/>
+		<rect class="building-front" x="1880" y="1780" width="170" height="300" rx="8"/>
+		<rect class="building-front" x="2080" y="1680" width="160" height="280" rx="8"/>
+		<rect class="building-front" x="2280" y="1560" width="150" height="260" rx="8"/>
+	</g>
+
+	<!-- Optional overlays (labels/icons) left empty for runtime) -->
+	<g id="layer-overlays" data-layer="overlays" data-parallax-x="0.9" data-parallax-y="0.9" class="overlay"></g>
+</svg>

--- a/Assets/Maps/DowntownManhattan/downtown_manhattan_fictional_map.json
+++ b/Assets/Maps/DowntownManhattan/downtown_manhattan_fictional_map.json
@@ -1,0 +1,42 @@
+{
+	"mapName": "Fictional Downtown Manhattan",
+	"version": "1.0.0",
+	"sourceSvg": "downtown_manhattan_fictional.svg",
+	"canvas": { "width": 4096, "height": 2304, "pixelsPerUnit": 256, "origin": "top-left" },
+	"sortingLayers": ["Background", "Midground", "Foreground", "UI"],
+	"layers": [
+		{ "id": "layer-water", "type": "background", "sortingLayer": "Background", "orderInLayer": 0, "parallax": { "x": 0.2, "y": 0.2 } },
+		{ "id": "layer-land", "type": "terrain", "sortingLayer": "Background", "orderInLayer": 10, "parallax": { "x": 0.4, "y": 0.4 }, "collider": { "type": "polygon", "source": "path.land", "isTrigger": false } },
+		{ "id": "layer-parks", "type": "decoration", "sortingLayer": "Midground", "orderInLayer": 20, "parallax": { "x": 0.45, "y": 0.45 } },
+		{ "id": "layer-piers", "type": "structure", "sortingLayer": "Midground", "orderInLayer": 25, "parallax": { "x": 0.35, "y": 0.35 } },
+		{ "id": "layer-roads-arterial", "type": "road", "sortingLayer": "Midground", "orderInLayer": 30, "parallax": { "x": 0.55, "y": 0.55 }, "nav": { "walkable": true, "speedMultiplier": 1.15 } },
+		{ "id": "layer-roads-secondary", "type": "road", "sortingLayer": "Midground", "orderInLayer": 31, "parallax": { "x": 0.6, "y": 0.6 }, "nav": { "walkable": true, "speedMultiplier": 1.05 } },
+		{ "id": "layer-roads-tertiary", "type": "road", "sortingLayer": "Midground", "orderInLayer": 32, "parallax": { "x": 0.62, "y": 0.62 }, "nav": { "walkable": true, "speedMultiplier": 1.0 } },
+		{ "id": "layer-buildings-back", "type": "building", "sortingLayer": "Foreground", "orderInLayer": 5, "parallax": { "x": 0.7, "y": 0.7 }, "collider": { "type": "box", "source": "rect.building-back", "isTrigger": true } },
+		{ "id": "layer-buildings-front", "type": "building", "sortingLayer": "Foreground", "orderInLayer": 8, "parallax": { "x": 0.8, "y": 0.8 }, "collider": { "type": "box", "source": "rect.building-front", "isTrigger": true } },
+		{ "id": "layer-overlays", "type": "overlay", "sortingLayer": "UI", "orderInLayer": 0, "parallax": { "x": 0.9, "y": 0.9 } }
+	],
+	"spawnPoints": [
+		{"name": "Player_Start_BatteryPark", "position": {"x": 1220, "y": 2020}},
+		{"name": "Enemy_Spawn_Financial", "position": {"x": 1680, "y": 1840}},
+		{"name": "Pickup_Spawn_ParkSouth", "position": {"x": 1460, "y": 1980}}
+	],
+	"paths": [
+		{"name": "Patrol_Broadway", "nodes": [[940,2100],[1180,2010],[1400,1900],[1620,1760],[1820,1600],[2020,1420],[2200,1240],[2360,1060]]},
+		{"name": "Route_WestSide", "nodes": [[900,2090],[1200,2050],[1500,1990],[1780,1880],[1980,1760]]}
+	],
+	"cameraBounds": {"minX": 800, "minY": 1200, "maxX": 3000, "maxY": 2150},
+	"minimap": {"scale": 0.1, "backgroundColor": "#0b3d59"},
+	"unity": {
+		"import": {
+			"package": "com.unity.vectorgraphics",
+			"spriteImportMode": "Single",
+			"svgPixelsPerUnit": 256,
+			"preserveViewport": true
+		},
+		"sorting": {
+			"createSortingLayers": true
+		}
+	},
+	"notes": "Parallax values match data attributes in SVG groups. Use a parallax controller to offset each layer based on camera movement. If importing as a single sprite, treat parallax as decoration only."
+}


### PR DESCRIPTION
Add a fictional background map layout of downtown Manhattan, including an SVG asset and Unity-ready JSON metadata for parallax and sorting.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1fc6c86-f980-46e3-ae4a-1d243cf6d1c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1fc6c86-f980-46e3-ae4a-1d243cf6d1c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

