### PR TITLE
Create nyc terrain with custom textures

### DIFF
--- a/Assets/Editor/TerrainSetupEditor.cs
+++ b/Assets/Editor/TerrainSetupEditor.cs
@@ -1,0 +1,134 @@
+using UnityEditor;
+using UnityEngine;
+
+// Editor utilities to set up Terrain layers and paint textures using optional masks.
+// Menu:
+// - Tools/Terrain/Assign Default TerrainLayers
+// - Tools/Terrain/Apply Splat From Masks
+// Place mask textures under Resources/Terrain/Textures and ensure they are Read/Write enabled.
+public static class TerrainSetupEditor
+{
+	[MenuItem("Tools/Terrain/Assign Default TerrainLayers")] 
+	public static void AssignDefaultTerrainLayers()
+	{
+		Terrain terrain = Object.FindObjectOfType<Terrain>();
+		if (terrain == null)
+		{
+			Debug.LogError("No Terrain found in the scene. Create or select a Terrain first.");
+			return;
+		}
+
+		// Load all TerrainLayer assets from Resources/Terrain/Layers
+		TerrainLayer[] layers = Resources.LoadAll<TerrainLayer>("Terrain/Layers");
+		if (layers == null || layers.Length == 0)
+		{
+			Debug.LogError("No TerrainLayer assets found under Resources/Terrain/Layers.");
+			return;
+		}
+
+		Undo.RecordObject(terrain.terrainData, "Assign Terrain Layers");
+		terrain.terrainData.terrainLayers = layers;
+		EditorUtility.SetDirty(terrain.terrainData);
+		Debug.Log($"Assigned {layers.Length} TerrainLayers to '{terrain.name}'.");
+	}
+
+	[MenuItem("Tools/Terrain/Apply Splat From Masks")] 
+	public static void ApplySplatFromMasks()
+	{
+		Terrain terrain = Object.FindObjectOfType<Terrain>();
+		if (terrain == null)
+		{
+			Debug.LogError("No Terrain found in the scene. Create or select a Terrain first.");
+			return;
+		}
+
+		TerrainData td = terrain.terrainData;
+		int w = td.alphamapWidth;
+		int h = td.alphamapHeight;
+		int numLayers = td.alphamapLayers;
+		if (numLayers == 0)
+		{
+			Debug.LogError("Terrain has no layers. Run Tools/Terrain/Assign Default TerrainLayers first.");
+			return;
+		}
+
+		// Try to load masks from Resources. Missing masks are treated as zero weight.
+		Texture2D grassMask = Resources.Load<Texture2D>("Terrain/Textures/grass-heightmap");
+		Texture2D dirtMask = Resources.Load<Texture2D>("Terrain/Textures/dirt");
+		Texture2D sandMask = Resources.Load<Texture2D>("Terrain/Textures/sand");
+		Texture2D soilMask = Resources.Load<Texture2D>("Terrain/Textures/soil");
+
+		bool anyMask = grassMask || dirtMask || sandMask || soilMask;
+		if (!anyMask)
+		{
+			Debug.LogWarning("No mask textures found in Resources/Terrain/Textures. Painting will default to layer 0.");
+		}
+
+		if (!IsReadable(grassMask) || !IsReadable(dirtMask) || !IsReadable(sandMask) || !IsReadable(soilMask))
+		{
+			Debug.LogWarning("One or more masks are not readable. Enable Read/Write on their import settings.");
+		}
+
+		float[,,] splat = new float[h, w, numLayers];
+
+		for (int y = 0; y < h; y++)
+		{
+			for (int x = 0; x < w; x++)
+			{
+				float u = (float)x / (w - 1);
+				float v = (float)y / (h - 1);
+
+				// Sample masks as grayscale in [0..1]
+				float g = SampleGray(grassMask, u, v);
+				float d = SampleGray(dirtMask, u, v);
+				float s = SampleGray(sandMask, u, v);
+				float o = SampleGray(soilMask, u, v);
+
+				// Collect up to first 4 layers. If there are more layers, extra ones will be zeroed.
+				float[] weights = new float[numLayers];
+				if (numLayers > 0) weights[0] = g;
+				if (numLayers > 1) weights[1] = d;
+				if (numLayers > 2) weights[2] = s;
+				if (numLayers > 3) weights[3] = o;
+
+				float sum = 0f;
+				for (int i = 0; i < numLayers; i++) sum += weights[i];
+				if (sum <= 0.0001f)
+				{
+					// Default all weight to first layer when no mask signal
+					weights[0] = 1f;
+					sum = 1f;
+				}
+
+				for (int i = 0; i < numLayers; i++)
+					splat[y, x, i] = weights[i] / sum;
+			}
+		}
+
+		Undo.RecordObject(td, "Apply Splat From Masks");
+		td.SetAlphamaps(0, 0, splat);
+		EditorUtility.SetDirty(td);
+		Debug.Log($"Applied splatmaps ({w}x{h}) using available masks to '{terrain.name}'.");
+	}
+
+	private static bool IsReadable(Texture2D tex)
+	{
+		if (tex == null) return true; // treat missing as readable to keep flow
+		try
+		{
+			tex.GetPixel(0, 0);
+			return true;
+		}
+		catch
+		{
+			return false;
+		}
+	}
+
+	private static float SampleGray(Texture2D tex, float u, float v)
+	{
+		if (tex == null) return 0f;
+		Color c = tex.GetPixelBilinear(u, v);
+		return Mathf.Clamp01(c.grayscale);
+	}
+}

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -1,148 +1,157 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.AI;
 
 public class GameManager : MonoBehaviour
 {
-    public static GameManager instance;
+	public static GameManager instance;
 
-    [Header("Canvas")]
-    public Canvas canvas;
-    public float canvasScaleFactor;
+	[Header("Canvas")]
+	public Canvas canvas;
+	public float canvasScaleFactor;
 
-    [Header("Game Parameters")]
-    public GameGlobalParameters gameGlobalParameters;
-    public GamePlayersParameters gamePlayersParameters;
-    public GameSoundParameters gameSoundParameters;
-    public GameInputParameters gameInputParameters;
-    public GameObject fov;
+	[Header("Game Parameters")]
+	public GameGlobalParameters gameGlobalParameters;
+	public GamePlayersParameters gamePlayersParameters;
+	public GameSoundParameters gameSoundParameters;
+	public GameInputParameters gameInputParameters;
+	public GameObject fov;
 
-    [Header("Minimap")]
-    public Transform minimapAnchor;
-    public Camera minimapCamera;
-    public Minimap minimapScript;
-    public BoxCollider mapWrapperCollider;
-    public int terrainSize;
-    private const float _TERRAIN_MID_HEIGHT = 30f;
+	[Header("Minimap")]
+	public Transform minimapAnchor;
+	public Camera minimapCamera;
+	public Minimap minimapScript;
+	public BoxCollider mapWrapperCollider;
+	public int terrainSize;
+	private const float _TERRAIN_MID_HEIGHT = 30f;
 
-    [HideInInspector]
-    public bool gameIsPaused;
+	[HideInInspector]
+	public bool gameIsPaused;
 
-    [HideInInspector]
-    public float producingRate = 3f; // in seconds
+	[HideInInspector]
+	public float producingRate = 3f; // in seconds
 
-    [HideInInspector]
-    public bool waitingForInput;
-    [HideInInspector]
-    public string pressedKey;
+	[HideInInspector]
+	public bool waitingForInput;
+	[HideInInspector]
+	public string pressedKey;
 
-    private void Awake()
-    {
-        canvasScaleFactor = canvas.scaleFactor;
+	private void Awake()
+	{
+		// Cache current UI scale for screen-to-world conversions
+		canvasScaleFactor = canvas.scaleFactor;
 
-        DataHandler.LoadGameData();
-        GetComponent<DayAndNightCycler>().enabled = gameGlobalParameters.enableDayAndNightCycle;
+		// Load saved player/settings data and enable optional systems
+		DataHandler.LoadGameData();
+		GetComponent<DayAndNightCycler>().enabled = gameGlobalParameters.enableDayAndNightCycle;
 
-        Globals.InitializeGameResources(gamePlayersParameters.players.Length);
+		// Initialize global resource slots and navigation
+		Globals.InitializeGameResources(gamePlayersParameters.players.Length);
 
-        Globals.NAV_MESH_SURFACE = GameObject.Find("Terrain").GetComponent<NavMeshSurface>();
-        Globals.UpdateNavMeshSurface();
+		// Expect a GameObject named "Terrain" with a NavMeshSurface
+		Globals.NAV_MESH_SURFACE = GameObject.Find("Terrain").GetComponent<NavMeshSurface>();
+		Globals.UpdateNavMeshSurface();
 
-        // enable/disable FOV depending on game parameters
-        fov.SetActive(gameGlobalParameters.enableFOV);
+		// enable/disable FOV depending on game parameters
+		fov.SetActive(gameGlobalParameters.enableFOV);
 
-        _SetupMinimap();
+		// Minimap camera and wrapper collider sized to current terrain bounds
+		_SetupMinimap();
 
-        gameIsPaused = false;
-    }
+		gameIsPaused = false;
+	}
 
-    public void Start()
-    {
-        instance = this;
-    }
+	public void Start()
+	{
+		instance = this;
+	}
 
-    private void _SetupMinimap()
-    {
-        Bounds b = GameObject.Find("Terrain").GetComponent<Terrain>().terrainData.bounds;
+	// Positions the minimap, sets orthographic size, and synchronizes the wrapper collider
+	private void _SetupMinimap()
+	{
+		Bounds b = GameObject.Find("Terrain").GetComponent<Terrain>().terrainData.bounds;
 
-        terrainSize = (int) b.size.x;
-        float p = terrainSize / 2;
+		terrainSize = (int) b.size.x;
+		float p = terrainSize / 2;
 
-        minimapAnchor.position = new Vector3(p, 0, p);
-        minimapCamera.orthographicSize = p;
-        mapWrapperCollider.center = new Vector3(0, _TERRAIN_MID_HEIGHT, 0);
-        mapWrapperCollider.size = new Vector3(b.size.x, 1f, b.size.z);
-        minimapScript.terrainSize = Vector2.one * terrainSize;
-    }
+		// Center the minimap camera over the terrain square
+		minimapAnchor.position = new Vector3(p, 0, p);
+		minimapCamera.orthographicSize = p;
+		// Wrapper collider used for clamping and FOV computations
+		mapWrapperCollider.center = new Vector3(0, _TERRAIN_MID_HEIGHT, 0);
+		mapWrapperCollider.size = new Vector3(b.size.x, 1f, b.size.z);
+		minimapScript.terrainSize = Vector2.one * terrainSize;
+	}
 
-    private void Update()
-    {
-        if (Input.anyKeyDown)
-        {
-            if (waitingForInput)
-            {
-                if (Input.GetMouseButtonDown(0))
-                    pressedKey = "mouse 0";
-                else if (Input.GetMouseButtonDown(1))
-                    pressedKey = "mouse 1";
-                else if (Input.GetMouseButtonDown(2))
-                    pressedKey = "mouse 2";
-                else
-                    pressedKey = Input.inputString;
-                waitingForInput = false;
-            }
-            else
-                gameInputParameters.CheckForInput();
-        }
-    }
+	private void Update()
+	{
+		if (Input.anyKeyDown)
+		{
+			if (waitingForInput)
+			{
+				// Capture the physical input description when rebinding keys
+				if (Input.GetMouseButtonDown(0))
+					pressedKey = "mouse 0";
+				else if (Input.GetMouseButtonDown(1))
+					pressedKey = "mouse 1";
+				else if (Input.GetMouseButtonDown(2))
+					pressedKey = "mouse 2";
+				else
+					pressedKey = Input.inputString;
+				waitingForInput = false;
+			}
+			else
+				gameInputParameters.CheckForInput();
+		}
+	}
 
-    private void OnEnable()
-    {
-        EventManager.AddListener("PausedGame", _OnPausedGame);
-        EventManager.AddListener("ResumedGame", _OnResumedGame);
+	private void OnEnable()
+	{
+		EventManager.AddListener("PausedGame", _OnPausedGame);
+		EventManager.AddListener("ResumedGame", _OnResumedGame);
 
-        EventManager.AddListener("UpdateGameParameter:enableDayAndNightCycle", _OnUpdateDayAndNightCycle);
-        EventManager.AddListener("UpdateGameParameter:enableFOV", _OnUpdateFOV);
-    }
+		EventManager.AddListener("UpdateGameParameter:enableDayAndNightCycle", _OnUpdateDayAndNightCycle);
+		EventManager.AddListener("UpdateGameParameter:enableFOV", _OnUpdateFOV);
+	}
 
-    private void OnDisable()
-    {
-        EventManager.RemoveListener("PausedGame", _OnPausedGame);
-        EventManager.RemoveListener("ResumedGame", _OnResumedGame);
+	private void OnDisable()
+	{
+		EventManager.RemoveListener("PausedGame", _OnPausedGame);
+		EventManager.RemoveListener("ResumedGame", _OnResumedGame);
 
-        EventManager.RemoveListener("UpdateGameParameter:enableDayAndNightCycle", _OnUpdateDayAndNightCycle);
-        EventManager.RemoveListener("UpdateGameParameter:enableFOV", _OnUpdateFOV);
-    }
+		EventManager.RemoveListener("UpdateGameParameter:enableDayAndNightCycle", _OnUpdateDayAndNightCycle);
+		EventManager.RemoveListener("UpdateGameParameter:enableFOV", _OnUpdateFOV);
+	}
 
-    private void _OnPausedGame()
-    {
-        gameIsPaused = true;
-        Time.timeScale = 0;
-    }
+	private void _OnPausedGame()
+	{
+		gameIsPaused = true;
+		Time.timeScale = 0;
+	}
 
-    private void _OnResumedGame()
-    {
-        gameIsPaused = false;
-        Time.timeScale = 1;
-    }
+	private void _OnResumedGame()
+	{
+		gameIsPaused = false;
+		Time.timeScale = 1;
+	}
 
-    /* game parameters update */
-    private void _OnUpdateDayAndNightCycle(object data)
-    {
-        bool dayAndNightIsOn = (bool)data;
-        GetComponent<DayAndNightCycler>().enabled = dayAndNightIsOn;
-    }
-    private void _OnUpdateFOV(object data)
-    {
-        bool fovIsOn = (bool)data;
-        fov.SetActive(fovIsOn);
-    }
+	/* game parameters update */
+	private void _OnUpdateDayAndNightCycle(object data)
+	{
+		bool dayAndNightIsOn = (bool)data;
+		GetComponent<DayAndNightCycler>().enabled = dayAndNightIsOn;
+	}
+	private void _OnUpdateFOV(object data)
+	{
+		bool fovIsOn = (bool)data;
+		fov.SetActive(fovIsOn);
+	}
 
-    private void OnApplicationQuit()
-    {
+	private void OnApplicationQuit()
+	{
 #if !UNITY_EDITOR
-        DataHandler.SaveGameData();
+		DataHandler.SaveGameData();
 #endif
-    }
+	}
 }

--- a/Assets/Scripts/Tools/MapMetadataExtractor.cs
+++ b/Assets/Scripts/Tools/MapMetadataExtractor.cs
@@ -3,57 +3,69 @@ using UnityEditor;
 using UnityEngine.SceneManagement;
 using UnityEditor.SceneManagement;
 
+// Extracts and saves basic map metadata (map size, max players, scene name)
+// into a ScriptableObject under Assets/Resources/ScriptableObjects/Maps.
+// Use the menu item Tools/Maps/Extract Current Scene Metadata while your scene is open.
 public static class MapMetadataExtractor
 {
-    private static readonly string _mapDataFolder = "Resources/ScriptableObjects/Maps";
+	private static readonly string _mapDataFolder = "Resources/ScriptableObjects/Maps";
 
-    public static void Extract(Scene s)
-    {
-        // check the map metadata Scriptable Objects folder exists,
-        // or create it
-        if (!System.IO.Directory.Exists(Application.dataPath + $"/{_mapDataFolder}"))
-            System.IO.Directory.CreateDirectory(Application.dataPath + $"/{_mapDataFolder}");
+	// Adds a convenient menu item to extract metadata for the active scene
+	[MenuItem("Tools/Maps/Extract Current Scene Metadata")]
+	public static void ExtractActiveSceneMetadata()
+	{
+		// Get currently active scene and extract its metadata
+		Extract(SceneManager.GetActiveScene());
+	}
 
-        // get the scene name + set it as active
-        string sceneName = s.name;
-        EditorSceneManager.SetActiveScene(s);
+	public static void Extract(Scene s)
+	{
+		// check the map metadata Scriptable Objects folder exists,
+		// or create it
+		if (!System.IO.Directory.Exists(Application.dataPath + $"/{_mapDataFolder}"))
+			System.IO.Directory.CreateDirectory(Application.dataPath + $"/{_mapDataFolder}");
 
-        // try to get the "Terrain" object
-        GameObject[] objs = s.GetRootGameObjects();
-        Terrain terrain = null;
-        foreach (GameObject g in objs)
-        {
-            terrain = g.GetComponent<Terrain>();
-            if (terrain != null)
-                break;
-        }
-        if (terrain == null)
-        {
-            Debug.LogWarning("There is no 'Terrain' component in this scene!");
-            return;
-        }
+		// get the scene name + set it as active
+		string sceneName = s.name;
+		EditorSceneManager.SetActiveScene(s);
 
-        // try and get the map metadata Scriptable Object,
-        // or create and save it
-        string assetPath = $"Assets/{_mapDataFolder}/{sceneName}.asset";
-        MapData data = AssetDatabase.LoadAssetAtPath<MapData>(assetPath);
-        if (data == null)
-        {
-            data = ScriptableObject.CreateInstance<MapData>();
-            AssetDatabase.CreateAsset(data, assetPath);
-            data.mapName = sceneName;
-            data.sceneName = sceneName;
-        }
+		// try to get the "Terrain" object
+		GameObject[] objs = s.GetRootGameObjects();
+		Terrain terrain = null;
+		foreach (GameObject g in objs)
+		{
+			terrain = g.GetComponent<Terrain>();
+			if (terrain != null)
+				break;
+		}
+		if (terrain == null)
+		{
+			Debug.LogWarning("There is no 'Terrain' component in this scene!");
+			return;
+		}
 
-        // get the map size
-        Bounds bounds = terrain.terrainData.bounds;
-        data.mapSize = bounds.size.x;
+		// try and get the map metadata Scriptable Object,
+		// or create and save it
+		string assetPath = $"Assets/{_mapDataFolder}/{sceneName}.asset";
+		MapData data = AssetDatabase.LoadAssetAtPath<MapData>(assetPath);
+		if (data == null)
+		{
+			data = ScriptableObject.CreateInstance<MapData>();
+			AssetDatabase.CreateAsset(data, assetPath);
+			data.mapName = sceneName;
+			data.sceneName = sceneName;
+		}
 
-        // get the max number of players = number of spawnpoints
-        data.maxPlayers = GameObject.Find("Spawnpoints").transform.childCount;
+		// get the map size from Terrain bounds (assumes square terrain)
+		Bounds bounds = terrain.terrainData.bounds;
+		data.mapSize = bounds.size.x;
 
-        // update the Scriptable Object
-        EditorUtility.SetDirty(data);
-        AssetDatabase.SaveAssets();
-    }
+		// get the max number of players = number of spawnpoints
+		// (expects a top-level GameObject named "Spawnpoints" with children)
+		data.maxPlayers = GameObject.Find("Spawnpoints").transform.childCount;
+
+		// update the Scriptable Object
+		EditorUtility.SetDirty(data);
+		AssetDatabase.SaveAssets();
+	}
 }

--- a/Assets/Scripts/UI/Minimap.cs
+++ b/Assets/Scripts/UI/Minimap.cs
@@ -1,53 +1,58 @@
-﻿using UnityEngine.EventSystems;
+using UnityEngine.EventSystems;
 using UnityEngine;
 
 [RequireComponent(typeof(RectTransform))]
+// Handles drag interaction on the minimap UI and converts pointer position
+// back to world-space coordinates on the Terrain, then emits an event.
 public class Minimap : MonoBehaviour, IPointerDownHandler, IPointerUpHandler
 {
-    public RectTransform minimapContainerRectTransform;
-    public Vector2 terrainSize;
-    private Vector2 _uiSize;
+	public RectTransform minimapContainerRectTransform;
+	public Vector2 terrainSize;
+	private Vector2 _uiSize;
 
-    private Vector2 _offset;
-    private Vector2 _lastPointerPosition;
-    private bool _dragging = false;
+	private Vector2 _offset;
+	private Vector2 _lastPointerPosition;
+	private bool _dragging = false;
 
-    private void Start()
-    {
-        _offset = minimapContainerRectTransform.anchoredPosition;
-        _uiSize = GetComponent<RectTransform>().sizeDelta;
-        _lastPointerPosition = Input.mousePosition;
-    }
+	private void Start()
+	{
+		// Cache UI and initial offset for coordinate conversions
+		_offset = minimapContainerRectTransform.anchoredPosition;
+		_uiSize = GetComponent<RectTransform>().sizeDelta;
+		_lastPointerPosition = Input.mousePosition;
+	}
 
-    private void Update()
-    {
-        if (!_dragging) return;
+	private void Update()
+	{
+		if (!_dragging) return;
 
-        Vector2 delta = (Vector2) Input.mousePosition - _lastPointerPosition;
-        _lastPointerPosition = Input.mousePosition;
+		Vector2 delta = (Vector2) Input.mousePosition - _lastPointerPosition;
+		_lastPointerPosition = Input.mousePosition;
 
-        if (delta.magnitude > Mathf.Epsilon)
-        {
-            Vector2 uiPos =
-                (new Vector2(Input.mousePosition.x, Input.mousePosition.y) /
-                GameManager.instance.canvasScaleFactor) - _offset;
-            Vector3 realPos = new Vector3(
-                uiPos.x / _uiSize.x * terrainSize.x,
-                0f,
-                uiPos.y / _uiSize.y * terrainSize.y
-            );
-            realPos = Utils.ProjectOnTerrain(realPos);
-            EventManager.TriggerEvent("ClickedMinimap", realPos);
-        }
-    }
+		if (delta.magnitude > Mathf.Epsilon)
+		{
+			// Convert screen-space pointer into UI-space, then into world-space
+			Vector2 uiPos =
+				(new Vector2(Input.mousePosition.x, Input.mousePosition.y) /
+				GameManager.instance.canvasScaleFactor) - _offset;
+			Vector3 realPos = new Vector3(
+				uiPos.x / _uiSize.x * terrainSize.x,
+				0f,
+				uiPos.y / _uiSize.y * terrainSize.y
+			);
+			// Raycast down to snap onto the terrain surface
+			realPos = Utils.ProjectOnTerrain(realPos);
+			EventManager.TriggerEvent("ClickedMinimap", realPos);
+		}
+	}
 
-    public void OnPointerDown(PointerEventData eventData)
-    {
-        _dragging = true;
-    }
+	public void OnPointerDown(PointerEventData eventData)
+	{
+		_dragging = true;
+	}
 
-    public void OnPointerUp(PointerEventData eventData)
-    {
-        _dragging = false;
-    }
+	public void OnPointerUp(PointerEventData eventData)
+	{
+		_dragging = false;
+	}
 }

--- a/README_NYC_Terrain.md
+++ b/README_NYC_Terrain.md
@@ -1,0 +1,33 @@
+## NYC terrain setup (Unity)
+
+1) Create or duplicate a scene
+- Duplicate `Assets/Scenes/GameScene.unity` to `Assets/Scenes/GameScene_NYC.unity`.
+- Ensure there is a `Terrain` GameObject in the scene. You can assign `Assets/New Terrain.asset` to it or create a new Terrain from GameObject > 3D Object > Terrain.
+
+2) Assign terrain layers
+- Menu: Tools > Terrain > Assign Default TerrainLayers.
+- This attaches layers from `Resources/Terrain/Layers` (grass, dirt, sand, soil) which reference textures at `Resources/Terrain/Textures`.
+
+3) Optional: import an NYC heightmap
+- If you have a DEM (heightmap) for NYC, import it as a Texture2D and make sure "Read/Write Enabled" is ON.
+- Use Unity Terrain Tools (Window > Package Manager > Terrain Tools) to import the heightmap into the active Terrain.
+- If you do not have a heightmap yet, you can keep the terrain flat.
+
+4) Optional: paint textures via masks
+- Put grayscale mask textures into `Assets/Resources/Terrain/Textures/` with names:
+  - `grass-heightmap.png` (used for grass coverage)
+  - `dirt.png`, `sand.png`, `soil.png` (optional coverage masks)
+- Enable Read/Write for these textures (Import Settings).
+- Menu: Tools > Terrain > Apply Splat From Masks. The tool samples the masks and paints the alphamap. Missing masks default to the first layer.
+
+5) NavMesh and minimap
+- `GameManager` expects a `Terrain` object with a `NavMeshSurface` component. It auto-bakes at runtime via `Globals.UpdateNavMeshSurface()`.
+- Minimap sizing and world conversion are auto-configured in `GameManager._SetupMinimap()`.
+
+6) Save map metadata (size, spawnpoints, scene)
+- In your NYC scene, create a top-level `Spawnpoints` GameObject with one child per player.
+- Menu: Tools > Maps > Extract Current Scene Metadata to save a `MapData` asset in `Assets/Resources/ScriptableObjects/Maps/`.
+
+Notes
+- The provided layers use textures: grass, dirt, sand, soil. You can add more TerrainLayers by creating new `.terrainlayer` assets and placing them in `Resources/Terrain/Layers`.
+- The mask painter normalizes weights per pixel. If all masks are zero at a pixel, it assigns weight to the first layer.


### PR DESCRIPTION
Add Unity Editor tools and documentation for NYC terrain setup, and clarify core terrain-related scripts with comments.

This PR provides an in-editor workflow for setting up terrain layers and painting textures using masks, specifically to help the user create an NYC-based terrain. It also adds explanatory comments to `GameManager.cs`, `Minimap.cs`, and `MapMetadataExtractor.cs` to aid in understanding the existing terrain-related code.

---
<a href="https://cursor.com/background-agent?bcId=bc-1002ae68-82f1-4329-9b10-e1f8ad3f36c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1002ae68-82f1-4329-9b10-e1f8ad3f36c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

